### PR TITLE
fixed offsets navigate when interact with navbar items

### DIFF
--- a/src/presentation/components/navbar/NavBar.jsx
+++ b/src/presentation/components/navbar/NavBar.jsx
@@ -35,8 +35,16 @@ const NavBar = ({ mapRef }) => {
   const handleButtonClick = (buildingNumber) => {
     const building = buildings.find((b) => b.number === buildingNumber);
 
+    // Debug: Log the building object
+    console.log("Building found:", building);
+
     if (building && mapRef.current) {
+      // Debug: Log mapRef.current
+      console.log("mapRef.current:", mapRef.current);
+
       mapRef.current.focusOnBuilding(building);
+    } else {
+      console.error("Building not found or mapRef is null");
     }
   };
 


### PR DESCRIPTION
This pull request enhances the functionality of the `InteractiveMap` component by improving its building focus feature, adding initialization checks, and enhancing debugging capabilities. Key changes include a new mechanism for centering on buildings, better handling of map readiness, and additional debugging logs.

### Enhancements to building focus functionality:
* Refactored the `focusOnBuilding` method to include a `zoomThenCenter` function for smoother zooming and centering on a building. This includes calculating offsets dynamically based on the building's position within the map wrapper.
* Added a readiness check (`mapReady` state) to ensure the map is fully loaded before attempting to focus on a building. A polling mechanism with `setInterval` is used to wait for readiness if necessary.

### Initialization and state management improvements:
* Replaced direct `transformRef` initialization with an `onInit` callback to properly set the transform API reference when the `TransformWrapper` component initializes.
* Added an `onLoad` event to the map image to set the `mapReady` state to `true` once the image is fully loaded.

### Debugging enhancements:
* Added console logs to debug the `focusOnBuilding` method, including logs for `mapRef.current` and the selected building object in the `NavBar` component.
* Re-enabled the `onTransformed` callback for debugging transform state changes.