### PR TITLE
map: remove border to fill screen in desktop view

### DIFF
--- a/src/presentation/components/InteractiveMap/InteractiveMap.css
+++ b/src/presentation/components/InteractiveMap/InteractiveMap.css
@@ -2,12 +2,12 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 20px auto 10px 190px;
-  width: 85vw;
+  /* margin: 20px auto 10px 190px; */
+  /* background-color: red; */
+  width: 100%;
   height: 95vh;
   overflow: hidden;
-  background: white;
-  border: 3px solid black;
+
   border-radius: 10px;
   touch-action: manipulation;
 }

--- a/src/presentation/components/InteractiveMap/InteractiveMap.css
+++ b/src/presentation/components/InteractiveMap/InteractiveMap.css
@@ -2,13 +2,9 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  /* margin: 20px auto 10px 190px; */
-  /* background-color: red; */
   width: 100%;
   height: 95vh;
   overflow: hidden;
-
-  border-radius: 10px;
   touch-action: manipulation;
 }
 

--- a/src/presentation/components/InteractiveMap/InteractiveMap.jsx
+++ b/src/presentation/components/InteractiveMap/InteractiveMap.jsx
@@ -20,7 +20,7 @@ const InteractiveMap = forwardRef((props, ref) => {
   const mapWrapperRef = useRef(null);
 
   const initialScale = 0.7;
-  const initialPositionX = 50;
+  const initialPositionX = 20;
   const initialPositionY = 1500;
 
   const MIN_ZOOM = 0.5;


### PR DESCRIPTION
This pull request makes minor adjustments to the `InteractiveMap` component, focusing on the map's initial position and its container's styling for improved layout and flexibility.

Styling and layout improvements:

* Updated `InteractiveMap.css` to make the map container take up the full width, removed fixed margins and background styling, and commented out unnecessary styles for easier future adjustments.

Component behavior adjustment:

* Changed the initial horizontal position (`initialPositionX`) of the map from 50 to 20 in `InteractiveMap.jsx`, likely to better align the map content on load.